### PR TITLE
Support aws_autoscaling_notification(s)

### DIFF
--- a/cluster/README.rst
+++ b/cluster/README.rst
@@ -111,15 +111,11 @@ Adding sns-notification for autoscaling-group scales
 
 .. code:: hcl
 
-   #module "ecs_cluster" { ... }
+   module "ecs_cluster" {
+      # ...
 
-   resource "aws_autoscaling_notification" "cluster_status_error" {
-     group_names   = ["${module.ecs_cluster.autoscaling_group_name}"]
-     topic_arn     = "${aws_sns_topic.ex.arn}"
-     notifications = [
-       "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
-       "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
-     ]
+      autoscale_notification_ok_topic_arn = "${aws_sns_topic.ex.arn}"
+      autoscale_notification_ng_topic_arn = "${aws_sns_topic.ex_alert.arn}"
    }
 
 See more details about `Getting SNS Notifications When Your Auto Scaling Group Scales`_ in the official AWS docs.

--- a/cluster/autoscaling.tf
+++ b/cluster/autoscaling.tf
@@ -4,6 +4,24 @@
  * The below resources is optional.
  */
 
+resource "aws_autoscaling_notification" "ok" {
+  group_names   = ["${aws_autoscaling_group.app.name}"]
+  notifications = [
+    "autoscaling:EC2_INSTANCE_LAUNCH",
+    "autoscaling:EC2_INSTANCE_TERMINATE",
+  ]
+  topic_arn     = "${var.autoscale_notification_ok_topic_arn}"
+}
+
+resource "aws_autoscaling_notification" "ng" {
+  group_names   = ["${aws_autoscaling_group.app.name}"]
+  notifications = [
+    "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+    "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
+  ]
+  topic_arn     = "${var.autoscale_notification_ng_topic_arn}"
+}
+
 resource "aws_autoscaling_policy" "scale_out" {
   count                     = "${ length(keys(var.autoscale_thresholds)) != 0 ? 1 : 0 }"
 

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -109,6 +109,16 @@ variable "asg_extra_tags" {
 
 # AutoScaling
 
+variable "autoscale_notification_ok_topic_arn" {
+  description = "ARN of SNS Topic for notify to autoscaling:{EC2_INSTANCE_LAUNCH,autoscaling:EC2_INSTANCE_TERMINATE}"
+  default     = "" // default as no-notify
+}
+
+variable "autoscale_notification_ng_topic_arn" {
+  description = "ARN of SNS Topic for notify to autoscaling:{EC2_INSTANCE_LAUNCH_ERROR,autoscaling:EC2_INSTANCE_TERMINATE_ERROR}"
+  default     = "" // default as no-notify
+}
+
 variable "autoscale_thresholds" {
   description = "The values against which the specified statistic is compared"
   type        = "map"


### PR DESCRIPTION
Hope to creating resource `aws_autoscaling_notification` on module of cluster

And this resource(s) as optional (as the defalut, no creation)

## References

- https://www.terraform.io/docs/providers/aws/r/autoscaling_notification.html
- https://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_DescribeNotificationConfigurations.html
- https://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_NotificationConfiguration.html