### PR TITLE
Support multiple log groups creation for ecs-service

### DIFF
--- a/service_load_balancing/main.tf
+++ b/service_load_balancing/main.tf
@@ -50,8 +50,8 @@ resource "aws_iam_role_policy" "ecs_service" {
 }
 
 resource "aws_cloudwatch_log_group" "app" {
-  count             = "${ var.log_group != "" ? 1 : 0 }"
+  count             = "${ length(var.log_groups) }"
 
-  name              = "${var.log_group}"
+  name              = "${var.log_groups[count.index]}"
   retention_in_days = "${var.log_groups_expiration_days}"
 }

--- a/service_load_balancing/variables.tf
+++ b/service_load_balancing/variables.tf
@@ -114,9 +114,10 @@ variable "container_definitions" {
   type        = "string"
 }
 
-variable "log_group" {
-  description = "The Name of CloudWatch Log Group for ECS Task (Container)"
-  default     = "" // It it is empty, no creattion cloudwatch_log_group
+variable "log_groups" {
+  description = "The List of CloudWatch Log Group Name for ECS Task (Container)"
+  type        = "list"
+  default     = []
 }
 
 variable "log_groups_expiration_days" {


### PR DESCRIPTION
This proposal has **BC BRAEK** for converting type to variable

Hope to support multiple cloudwatch log groups creation for using ecs-service.

in many case, we split of streaming logs  if defined multiple container into one task definition.