### PR TITLE
aws_ecs_service ignores updating task_definition

### DIFF
--- a/service_load_balancing/README.rst
+++ b/service_load_balancing/README.rst
@@ -86,6 +86,18 @@ Basic Usage
    }
 
 
+A note of caution
+-----------------
+
+Currently `aws_ecs_service.main.task_definition` is ignored by lifecycle
+cause task_definition is updated often via continuous ecs deployment.
+
+Although it is a difficult decision, we hope to support dynamic lifecycle
+featured by Terraform.
+
+See detail: [#1](https://github.com/voyagegroup/tf_aws_ecs/issues/1)
+
+
 Advanced Usage
 ==============
 

--- a/service_load_balancing/main.tf
+++ b/service_load_balancing/main.tf
@@ -30,6 +30,7 @@ resource "aws_ecs_service" "main" {
     #       https://github.com/hashicorp/terraform/issues/3116
     ignore_changes = [
       "desired_count",
+      "task_definition",
     ]
   }
 


### PR DESCRIPTION
Case deployment process, we almost update ECS Task Definition into ECS Service.
But this module has changed in terraform plan cause aws_ecs_service.main.task definition attributes is not rebased on latest task definition.

Other deployments cases are also conceivable,
we hope to be ignore changed this.