### PR TITLE
Changing supported iam-role due by aws

### DIFF
--- a/service_load_balancing/autoscaling.tf
+++ b/service_load_balancing/autoscaling.tf
@@ -16,7 +16,7 @@ resource "aws_iam_role_policy_attachment" "service_autoscale" {
   count      = "${ length(keys(var.autoscale_thresholds)) != 0 ? 1 : 0 }"
 
   role       = "${aws_iam_role.service_autoscale.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole"
+  policy_arn = "arn:aws:iam::aws:policy/aws-service-role/AWSApplicationAutoscalingECSServicePolicy"
 }
 
 resource "aws_appautoscaling_target" "main" {


### PR DESCRIPTION
IAM Role for AWS ECS appautoscaling is more policies

`$ diff AmazonEC2ContainerServiceAutoscaleRole.json AWSApplicationAutoscalingECSServicePolicy.json`
```diff
8,17c8,11
<                 "ecs:UpdateService"
<             ],
<             "Resource": [
<                 "*"
<             ]
<         },
<         {
<             "Effect": "Allow",
<             "Action": [
<                 "cloudwatch:DescribeAlarms"
---
>                 "ecs:UpdateService",
>                 "cloudwatch:PutMetricAlarm",
>                 "cloudwatch:DescribeAlarms",
>                 "cloudwatch:DeleteAlarms"
```
