### PR TITLE
autoscale_thresholds splits to scale_{in,out}_thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,74 @@
 ## 0.3.0 (Unreleased)
 
+**BC BREAKS:** cluster & service_load_balancing module: variable `autoscale_thresholds` splits
+to `scale_out_thresholds` / `scale_in_thresholds`
+
+Code migrations example:
+
+- cluster:
+
+```hcl
+# Before:
+module "ex_ecs_cluster" {
+  source                    = "git@github.com:voyagegroup/tf_aws_ecs?ref=v0.2.2//cluster"
+  # ...
+  autoscale_thresholds      = {
+    cpu_reservation_high    = 70
+    cpu_reservation_low     = 10
+    memory_reservation_high = 80
+    memory_reservation_low  = 20
+  }
+}
+
+# After:
+module "ex_ecs_cluster" {
+  source               = "git@github.com:voyagegroup/tf_aws_ecs?ref=v0.3.0//cluster"
+  # ...
+  scale_out_thresholds = {
+    cpu_util           = 70
+    cpu_reservation    = 70
+    memory_util        = 80
+    memory_reservation = 80
+  }
+  scale_in_thresholds  = {
+    cpu_util           = 70
+    cpu_reservation    = 10
+    memory_util        = 20
+    memory_reservation = 20
+  }
+}
+```
+
+- service_load_balancing:
+
+```hcl
+# Before:
+module "ex_ecs_service" {
+  source               = "git@github.com:voyagegroup/tf_aws_ecs?ref=v0.2.2//service_load_balancing"
+  # ...
+  autoscale_thresholds = {
+    cpu_high    = 60
+    cpu_low     =  8
+    memory_high = 75
+    memory_low  = 10
+  }
+}
+
+# After:
+module "ex_ecs_service" {
+  source               = "git@github.com:voyagegroup/tf_aws_ecs?ref=v0.3.0//service_load_balancing"
+  # ...
+  scale_out_thresholds = {
+    cpu    = 60
+    memory = 75
+  }
+  scale_in_thresholds  = {
+    cpu    =  8
+    memory = 10
+  }
+}
+```
+
 * cluster: Parameterized to evaluation_periods
   * `scale_out_evaluation_periods` (default: 1)
   * `scale_in_evaluation_periods` (default: 2)

--- a/cluster/README.rst
+++ b/cluster/README.rst
@@ -94,20 +94,23 @@ Enabled autoscaling
 
      # ...
 
-     autoscale_thresholds         = {
-       memory_reservation_high = 75
-       memory_reservation_low  = 40
-       // cpu_util_high        =
-       // cpu_util_low         =
-       // cpu_reservation_high =
-       // cpu_reservation_low  =
-       // memory_util_high     =
-       // memory_util_low      =
-     }
      #scale_out_ok_actions        = []
      scale_out_more_alarm_actions = ["${aws_sns_topic.ex_alert.arn}"]
+     scale_out_thresholds         = {
+       memory_reservation = 75
+       // cpu_util        =
+       // cpu_reservation =
+       // memory_util     =
+     }
+
      #scale_in_ok_actions         = []
      #scale_in_more_alarm_actions = []
+     scale_in_thresholds          = {
+       memory_reservation = 40
+       // cpu_util        =
+       // cpu_reservation =
+       // memory_util     =
+     }
    }
 
 See more details about `Scaling a Cluster`_ `What Is Auto Scaling?`_ in the official AWS docs.

--- a/cluster/autoscaling.tf
+++ b/cluster/autoscaling.tf
@@ -27,7 +27,7 @@ resource "aws_autoscaling_notification" "ng" {
 }
 
 resource "aws_autoscaling_policy" "scale_out" {
-  count                     = "${ length(keys(var.autoscale_thresholds)) != 0 ? 1 : 0 }"
+  count                     = "${ length(keys(var.scale_out_thresholds)) != 0 ? 1 : 0 }"
 
   name                      = "${aws_ecs_cluster.main.name}-ECSCluster-ScaleOut"
   autoscaling_group_name    = "${aws_autoscaling_group.app.name}"
@@ -37,7 +37,7 @@ resource "aws_autoscaling_policy" "scale_out" {
 }
 
 resource "aws_autoscaling_policy" "scale_in" {
-  count                     = "${ length(keys(var.autoscale_thresholds)) != 0 ? 1 : 0 }"
+  count                     = "${ length(keys(var.scale_in_thresholds)) != 0 ? 1 : 0 }"
 
   name                      = "${aws_ecs_cluster.main.name}-ECSCluster-ScaleIn"
   autoscaling_group_name    = "${aws_autoscaling_group.app.name}"
@@ -49,7 +49,7 @@ resource "aws_autoscaling_policy" "scale_in" {
 // Memory Utilization
 
 resource "aws_cloudwatch_metric_alarm" "memory_util_high" {
-  count               = "${ lookup(var.autoscale_thresholds, "memory_util_high", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_out_thresholds, "memory_util", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryUtilization-High"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by memory-util-high"
@@ -59,7 +59,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_util_high" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_period}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["memory_util_high"]}"
+  threshold           = "${var.scale_out_thresholds["memory_util"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {
@@ -74,7 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_util_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_util_low" {
-  count               = "${ lookup(var.autoscale_thresholds, "memory_util_low", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_in_thresholds, "memory_util", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryUtilization-Low"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by memory-util-low"
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_util_low" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_period}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["memory_util_low"]}"
+  threshold           = "${var.scale_in_thresholds["memory_util"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_util_low" {
 // CPU Utilization
 
 resource "aws_cloudwatch_metric_alarm" "cpu_util_high" {
-  count               = "${ lookup(var.autoscale_thresholds, "cpu_util_high", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_out_thresholds, "cpu_util", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUUtilization-High"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by cpu-util-high"
@@ -111,7 +111,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_util_high" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_period}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["cpu_util_high"]}"
+  threshold           = "${var.scale_out_thresholds["cpu_util"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {
@@ -126,7 +126,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_util_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_util_low" {
-  count               = "${ lookup(var.autoscale_thresholds, "cpu_util_low", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_in_thresholds, "cpu_util", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUUtilization-Low"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by cpu-util-low"
@@ -136,7 +136,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_util_low" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_period}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["cpu_util_low"]}"
+  threshold           = "${var.scale_in_thresholds["cpu_util"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {
@@ -153,7 +153,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_util_low" {
 // Memory Reservation
 
 resource "aws_cloudwatch_metric_alarm" "memory_reservation_high" {
-  count               = "${ lookup(var.autoscale_thresholds, "memory_reservation_high", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_out_thresholds, "memory_reservation", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryReservation-High"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by memory-reservation-high"
@@ -163,7 +163,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_reservation_high" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_period}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["memory_reservation_high"]}"
+  threshold           = "${var.scale_out_thresholds["memory_reservation"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {
@@ -178,7 +178,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_reservation_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_reservation_low" {
-  count               = "${ lookup(var.autoscale_thresholds, "memory_reservation_low", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_in_thresholds, "memory_reservation", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryReservation-Low"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by memory-reservation-low"
@@ -188,7 +188,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_reservation_low" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_period}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["memory_reservation_low"]}"
+  threshold           = "${var.scale_in_thresholds["memory_reservation"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {
@@ -205,7 +205,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_reservation_low" {
 // CPU Reservation
 
 resource "aws_cloudwatch_metric_alarm" "cpu_reservation_high" {
-  count               = "${ lookup(var.autoscale_thresholds, "cpu_reservation_high", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_out_thresholds, "cpu_reservation", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUReservation-High"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by cpu-reservation-high"
@@ -215,7 +215,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_reservation_high" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_period}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["cpu_reservation_high"]}"
+  threshold           = "${var.scale_out_thresholds["cpu_reservation"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {
@@ -230,7 +230,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_reservation_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_reservation_low" {
-  count               = "${ lookup(var.autoscale_thresholds, "cpu_reservation_low", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_in_thresholds, "cpu_reservation", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUReservation-Low"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by cpu-reservation-low"
@@ -240,7 +240,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_reservation_low" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_period}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["cpu_reservation_low"]}"
+  threshold           = "${var.scale_in_thresholds["cpu_reservation"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -124,22 +124,6 @@ variable "autoscale_notification_ng_topic_arn" {
   default     = "" // default as no-notify
 }
 
-variable "autoscale_thresholds" {
-  description = "The values against which the specified statistic is compared"
-  type        = "map"
-  default     = {
-    # Supporting thresholds as berow
-    #cpu_util_high           = // e.g. 75
-    #cpu_util_low            = // e.g.  5
-    #cpu_reservation_high    = // e.g. 75
-    #cpu_reservation_low     = // e.g.  5
-    #memory_util_high        = // e.g. 75
-    #memory_util_low         = // e.g. 40
-    #memory_reservation_high = // e.g. 75
-    #memory_reservation_low  = // e.g. 40
-  }
-}
-
 variable "autoscale_period" {
   description = "The period in seconds over which the specified applied for autoscaling"
   default     = 300
@@ -150,24 +134,18 @@ variable "autoscale_cooldown" {
   default     = 300
 }
 
-variable "scale_out_evaluation_periods" {
-  description = "The number of evaluation periods to scale out"
-  default     = 1
-}
+# AutoScaling > scale-out
 
-variable "scale_in_evaluation_periods" {
-  description = "The number of evaluation periods to scale in"
-  default     = 2
-}
-
-variable "scale_out_adjustment" {
-  description = "The number of instances by which to scale out"
-  default     = 1
-}
-
-variable "scale_in_adjustment" {
-  description = "The number of instances by which to scale out"
-  default     = -1
+variable "scale_out_thresholds" {
+  description = "The values against which the specified statistic is compared"
+  type        = "map"
+  default     = {
+    # Supporting thresholds as berow
+    #cpu_util          = // e.g. 75
+    #cpu_reservation   = // e.g. 75
+    #memory_util       = // e.g. 75
+    #memory_reservaion = // e.g. 75
+  }
 }
 
 variable "scale_out_ok_actions" {
@@ -180,6 +158,40 @@ variable "scale_out_more_alarm_actions" {
   description = "For scale-out as same as alarm actions for cloudwatch alarms"
   type        = "list"
   default     = []
+}
+
+variable "scale_out_evaluation_periods" {
+  description = "The number of evaluation periods to scale out"
+  default     = 1
+}
+
+variable "scale_out_adjustment" {
+  description = "The number of instances by which to scale out"
+  default     = 1
+}
+
+# AutoScaling > scale-in
+
+variable "scale_in_thresholds" {
+  description = "The values against which the specified statistic is compared for scale_in"
+  type        = "map"
+  default     = {
+    # Supporting thresholds as berow
+    #cpu_util           = // e.g.  5
+    #cpu_reservation    = // e.g.  5
+    #memory_util        = // e.g. 40
+    #memory_reservation = // e.g. 40
+  }
+}
+
+variable "scale_in_evaluation_periods" {
+  description = "The number of evaluation periods to scale in"
+  default     = 2
+}
+
+variable "scale_in_adjustment" {
+  description = "The number of instances by which to scale out"
+  default     = -1
 }
 
 variable "scale_in_ok_actions" {

--- a/service_load_balancing/README.rst
+++ b/service_load_balancing/README.rst
@@ -120,22 +120,24 @@ Enabled autoscaling
      autoscale_iam_role_arn        = "${data.aws_iam_role.ecs_autoscale_service_linked_role.arn}"
      autoscale_min_capacity        = 2
      autoscale_max_capacity        = 8
-     autoscale_thresholds          = {
-       memory_high = 75
-       memory_low  = 40
-       // cpu_high =
-       // cpu_low  =
-     }
 
      #scale_out_ok_actions         = []
      scale_out_more_alarm_actions  = ["${aws_sns_topic.ex_alert.arn}"]
+     scale_out_thresholds          = {
+       cpu    = 80
+       memory = 75
+     }
      scale_out_step_adjustment     = {
        metric_interval_lower_bound = 0
        scaling_adjustment          = 1
      }
 
-     #scale_in_actions             = []
-     #scale_out_more_alarm_actions = []
+     #scale_in_ok_actions          = []
+     #scale_in_more_alarm_actions  = []
+     scale_in_thresholds           = {
+       cpu    = 10
+       memory = 20
+     }
      scale_in_step_adjustment      = {
        metric_interval_upper_bound = 0
        scaling_adjustment          = -1

--- a/service_load_balancing/autoscaling.tf
+++ b/service_load_balancing/autoscaling.tf
@@ -5,7 +5,7 @@
  */
 
 resource "aws_appautoscaling_target" "main" {
-  count              = "${ length(keys(var.autoscale_thresholds)) != 0 ? 1 : 0 }"
+  count              = "${ var.autoscale_iam_role_arn != "" ? 1 : 0 }"
 
   max_capacity       = "${var.autoscale_max_capacity}"
   min_capacity       = "${var.autoscale_min_capacity}"
@@ -16,7 +16,7 @@ resource "aws_appautoscaling_target" "main" {
 }
 
 resource "aws_appautoscaling_policy" "scale_out" {
-  count              = "${ length(keys(var.autoscale_thresholds)) != 0 ? 1 : 0 }"
+  count              = "${ var.autoscale_iam_role_arn != "" ? 1 : 0 }"
 
   name               = "${aws_ecs_service.main.name}-ecs-service-scale-out"
   resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
@@ -38,7 +38,7 @@ resource "aws_appautoscaling_policy" "scale_out" {
 }
 
 resource "aws_appautoscaling_policy" "scale_in" {
-  count              = "${ length(keys(var.autoscale_thresholds)) != 0 ? 1 : 0 }"
+  count              = "${ var.autoscale_iam_role_arn != "" ? 1 : 0 }"
 
   name               = "${aws_ecs_service.main.name}-ecs-service-scale-in"
   resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
@@ -62,7 +62,7 @@ resource "aws_appautoscaling_policy" "scale_in" {
 // Memory Utilization
 
 resource "aws_cloudwatch_metric_alarm" "memory_high" {
-  count               = "${ lookup(var.autoscale_thresholds, "memory_high", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_out_thresholds, "memory", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_service.main.name}-ECSService-MemoryUtilization-High"
   alarm_description   = "${aws_ecs_service.main.name} scale-out pushed by memory-utilization-high"
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_high" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_cooldown}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["memory_high"]}"
+  threshold           = "${var.scale_out_thresholds["memory"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_low" {
-  count               = "${ lookup(var.autoscale_thresholds, "memory_low", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_in_thresholds, "memory", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_service.main.name}-ECSService-MemoryUtilization-Low"
   alarm_description   = "scale-in pushed by memory-utilization-low"
@@ -98,7 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_low" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_cooldown}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["memory_low"]}"
+  threshold           = "${var.scale_in_thresholds["memory"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {
@@ -116,7 +116,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_low" {
 // CPU Utilization
 
 resource "aws_cloudwatch_metric_alarm" "cpu_high" {
-  count               = "${ lookup(var.autoscale_thresholds, "cpu_high", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_out_thresholds, "cpu", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_service.main.name}-ECSService-CPUUtilization-High"
   alarm_description   = "${aws_ecs_service.main.name} scale-out pushed by cpu-utilization-high"
@@ -126,7 +126,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_high" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_cooldown}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["cpu_high"]}"
+  threshold           = "${var.scale_out_thresholds["cpu"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {
@@ -142,7 +142,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_low" {
-  count               = "${ lookup(var.autoscale_thresholds, "cpu_low", "") != "" ? 1 : 0 }"
+  count               = "${ lookup(var.scale_in_thresholds, "cpu", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_service.main.name}-ECSService-CPUUtilization-Low"
   alarm_description   = "${aws_ecs_service.main.name} scale-in pushed by cpu-utilization-low"
@@ -152,7 +152,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_low" {
   namespace           = "AWS/ECS"
   period              = "${var.autoscale_cooldown}"
   statistic           = "Average"
-  threshold           = "${var.autoscale_thresholds["cpu_low"]}"
+  threshold           = "${var.scale_in_thresholds["cpu"]}"
   treat_missing_data  = "notBreaching"
 
   dimensions {

--- a/service_load_balancing/variables.tf
+++ b/service_load_balancing/variables.tf
@@ -137,19 +137,6 @@ variable "autoscale_iam_role_arn" {
   default     = "" // not creates if empty
 }
 
-variable "autoscale_thresholds" {
-  description = "The values against which the specified statistic is compared"
-  type        = "map"
-  # No apply if empty
-  default     = {
-    # Supporting thresholds as berow
-    #cpu_high    = // e.g. 75
-    #cpu_row     = // e.g.  5
-    #memory_high = // e.g. 75
-    #memory_row  = // e.g. 40
-  }
-}
-
 variable "autoscale_max_capacity" {
   description = "The max capacity of the scalable target"
   default     = 1
@@ -165,6 +152,19 @@ variable "autoscale_cooldown" {
   default     = 300
 }
 
+# AutoScaling > scale-out
+
+variable "scale_out_thresholds" {
+  description = "The values against which the specified statistic is compared for scale_out"
+  type        = "map"
+  # No apply if empty
+  default     = {
+    # Supporting thresholds as berow
+    #cpu    = // e.g. 75
+    #memory = // e.g. 75
+  }
+}
+
 variable "scale_out_step_adjustment" {
   description = "The attributes of step scaling policy"
   type        = "map"
@@ -174,23 +174,9 @@ variable "scale_out_step_adjustment" {
   }
 }
 
-variable "scale_in_step_adjustment" {
-  description = "The attributes of step scaling policy"
-  type        = "map"
-  default     = {
-    metric_interval_upper_bound = 0
-    scaling_adjustment          = -1
-  }
-}
-
 variable "scale_out_evaluation_periods" {
   description = "The number of evaluation periods to scale out"
   default     = 1
-}
-
-variable "scale_in_evaluation_periods" {
-  description = "The number of evaluation periods to scale in"
-  default     = 2
 }
 
 variable "scale_out_ok_actions" {
@@ -205,6 +191,8 @@ variable "scale_out_more_alarm_actions" {
   default     = []
 }
 
+# AutoScaling > scale-in
+
 variable "scale_in_ok_actions" {
   description = "For scale-in as same as ok actions for cloudwatch alarms"
   type        = "list"
@@ -215,4 +203,29 @@ variable "scale_in_more_alarm_actions" {
   description = "For scale-in as same as alarm actions for cloudwatch alarms"
   type        = "list"
   default     = []
+}
+
+variable "scale_in_evaluation_periods" {
+  description = "The number of evaluation periods to scale in"
+  default     = 2
+}
+
+variable "scale_in_thresholds" {
+  description = "The values against which the specified statistic is compared for scale_in"
+  type        = "map"
+  # No apply if empty
+  default     = {
+    # Supporting thresholds as berow
+    #cpu    = // e.g.  5
+    #memory = // e.g. 40
+  }
+}
+
+variable "scale_in_step_adjustment" {
+  description = "The attributes of step scaling policy"
+  type        = "map"
+  default     = {
+    metric_interval_upper_bound = 0
+    scaling_adjustment          = -1
+  }
 }


### PR DESCRIPTION
For example, `autoscale_threshoulds.cpu_util_high` name has not mean `scale_out`...

This proposal has bc-breaks but names and natures do often so agree, and so simple :)