### PR TITLE
Fix creating only one autoscaling policy when specified multiple thresholds

### DIFF
--- a/cluster/autoscaling.tf
+++ b/cluster/autoscaling.tf
@@ -26,33 +26,23 @@ resource "aws_autoscaling_notification" "ng" {
   topic_arn     = "${var.autoscale_notification_ng_topic_arn}"
 }
 
-resource "aws_autoscaling_policy" "scale_out" {
-  count                     = "${ length(keys(var.scale_out_thresholds)) != 0 ? 1 : 0 }"
-
-  name                      = "${aws_ecs_cluster.main.name}-ECSCluster-ScaleOut"
-  autoscaling_group_name    = "${aws_autoscaling_group.app.name}"
-  scaling_adjustment        = "${var.scale_out_adjustment}"
-  adjustment_type           = "ChangeInCapacity"
-  cooldown                  = "${var.autoscale_cooldown}"
-}
-
-resource "aws_autoscaling_policy" "scale_in" {
-  count                     = "${ length(keys(var.scale_in_thresholds)) != 0 ? 1 : 0 }"
-
-  name                      = "${aws_ecs_cluster.main.name}-ECSCluster-ScaleIn"
-  autoscaling_group_name    = "${aws_autoscaling_group.app.name}"
-  scaling_adjustment        = "${var.scale_in_adjustment}"
-  adjustment_type           = "ChangeInCapacity"
-  cooldown                  = "${var.autoscale_cooldown}"
-}
-
 // Memory Utilization
+
+resource "aws_autoscaling_policy" "memory_util_high" {
+  count                  = "${ lookup(var.scale_out_thresholds, "memory_util", "") != "" ? 1 : 0 }"
+
+  name                   = "${aws_ecs_cluster.main.name}-scale_out-memory_util"
+  autoscaling_group_name = "${aws_autoscaling_group.app.name}"
+  scaling_adjustment     = "${var.scale_out_adjustment}"
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = "${var.autoscale_cooldown}"
+}
 
 resource "aws_cloudwatch_metric_alarm" "memory_util_high" {
   count               = "${ lookup(var.scale_out_thresholds, "memory_util", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryUtilization-High"
-  alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by memory-util-high"
+  alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by memory-util"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "${var.scale_out_evaluation_periods}"
   metric_name         = "MemoryUtilization"
@@ -61,23 +51,32 @@ resource "aws_cloudwatch_metric_alarm" "memory_util_high" {
   statistic           = "Average"
   threshold           = "${var.scale_out_thresholds["memory_util"]}"
   treat_missing_data  = "notBreaching"
+  ok_actions          = ["${compact(var.scale_out_ok_actions)}"]
+  alarm_actions       = [
+    "${aws_autoscaling_policy.memory_util_high.arn}",
+    "${compact(var.scale_out_more_alarm_actions)}",
+  ]
 
   dimensions {
     ClusterName = "${aws_ecs_cluster.main.name}"
   }
+}
 
-  ok_actions          = ["${compact(var.scale_out_ok_actions)}"]
-  alarm_actions       = [
-    "${aws_autoscaling_policy.scale_out.arn}",
-    "${compact(var.scale_out_more_alarm_actions)}",
-  ]
+resource "aws_autoscaling_policy" "memory_util_low" {
+  count                  = "${ lookup(var.scale_in_thresholds, "memory_util", "") != "" ? 1 : 0 }"
+
+  name                   = "${aws_ecs_cluster.main.name}-scale_in-memory_util"
+  autoscaling_group_name = "${aws_autoscaling_group.app.name}"
+  scaling_adjustment     = "${var.scale_in_adjustment}"
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = "${var.autoscale_cooldown}"
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_util_low" {
   count               = "${ lookup(var.scale_in_thresholds, "memory_util", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryUtilization-Low"
-  alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by memory-util-low"
+  alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by memory-util"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "${var.scale_in_evaluation_periods}"
   metric_name         = "MemoryUtilization"
@@ -86,25 +85,34 @@ resource "aws_cloudwatch_metric_alarm" "memory_util_low" {
   statistic           = "Average"
   threshold           = "${var.scale_in_thresholds["memory_util"]}"
   treat_missing_data  = "notBreaching"
+  ok_actions          = ["${compact(var.scale_in_ok_actions)}"]
+  alarm_actions       = [
+    "${aws_autoscaling_policy.memory_util_low.arn}",
+    "${compact(var.scale_in_more_alarm_actions)}",
+  ]
 
   dimensions {
     ClusterName = "${aws_ecs_cluster.main.name}"
   }
-
-  ok_actions          = ["${compact(var.scale_in_ok_actions)}"]
-  alarm_actions       = [
-    "${aws_autoscaling_policy.scale_in.arn}",
-    "${compact(var.scale_in_more_alarm_actions)}",
-  ]
 }
 
 // CPU Utilization
+
+resource "aws_autoscaling_policy" "cpu_util_high" {
+  count                  = "${ lookup(var.scale_out_thresholds, "cpu_util", "") != "" ? 1 : 0 }"
+
+  name                   = "${aws_ecs_cluster.main.name}-scale_out-cpu_util"
+  autoscaling_group_name = "${aws_autoscaling_group.app.name}"
+  scaling_adjustment     = "${var.scale_out_adjustment}"
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = "${var.autoscale_cooldown}"
+}
 
 resource "aws_cloudwatch_metric_alarm" "cpu_util_high" {
   count               = "${ lookup(var.scale_out_thresholds, "cpu_util", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUUtilization-High"
-  alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by cpu-util-high"
+  alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by cpu-util"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "${var.scale_out_evaluation_periods}"
   metric_name         = "CPUUtilization"
@@ -113,23 +121,32 @@ resource "aws_cloudwatch_metric_alarm" "cpu_util_high" {
   statistic           = "Average"
   threshold           = "${var.scale_out_thresholds["cpu_util"]}"
   treat_missing_data  = "notBreaching"
+  ok_actions          = ["${compact(var.scale_out_ok_actions)}"]
+  alarm_actions       = [
+    "${aws_autoscaling_policy.cpu_util_high.arn}",
+    "${compact(var.scale_out_more_alarm_actions)}",
+  ]
 
   dimensions {
     ClusterName = "${aws_ecs_cluster.main.name}"
   }
+}
 
-  ok_actions          = ["${compact(var.scale_out_ok_actions)}"]
-  alarm_actions       = [
-    "${aws_autoscaling_policy.scale_out.arn}",
-    "${compact(var.scale_out_more_alarm_actions)}",
-  ]
+resource "aws_autoscaling_policy" "cpu_util_low" {
+  count                  = "${ lookup(var.scale_in_thresholds, "cpu_util", "") != "" ? 1 : 0 }"
+
+  name                   = "${aws_ecs_cluster.main.name}-scale_in-cpu_util"
+  autoscaling_group_name = "${aws_autoscaling_group.app.name}"
+  scaling_adjustment     = "${var.scale_in_adjustment}"
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = "${var.autoscale_cooldown}"
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_util_low" {
   count               = "${ lookup(var.scale_in_thresholds, "cpu_util", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUUtilization-Low"
-  alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by cpu-util-low"
+  alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by cpu-util"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "${var.scale_in_evaluation_periods}"
   metric_name         = "CPUUtilization"
@@ -138,25 +155,34 @@ resource "aws_cloudwatch_metric_alarm" "cpu_util_low" {
   statistic           = "Average"
   threshold           = "${var.scale_in_thresholds["cpu_util"]}"
   treat_missing_data  = "notBreaching"
+  ok_actions          = ["${compact(var.scale_in_ok_actions)}"]
+  alarm_actions       = [
+    "${aws_autoscaling_policy.cpu_util_low.arn}",
+    "${compact(var.scale_in_more_alarm_actions)}",
+  ]
 
   dimensions {
     ClusterName = "${aws_ecs_cluster.main.name}"
   }
-
-  ok_actions          = ["${compact(var.scale_in_ok_actions)}"]
-  alarm_actions       = [
-    "${aws_autoscaling_policy.scale_in.arn}",
-    "${compact(var.scale_in_more_alarm_actions)}",
-  ]
 }
 
 // Memory Reservation
+
+resource "aws_autoscaling_policy" "memory_reservation_high" {
+  count               = "${ lookup(var.scale_out_thresholds, "memory_reservation", "") != "" ? 1 : 0 }"
+
+  name                      = "${aws_ecs_cluster.main.name}-scale_out-memory_reservation"
+  autoscaling_group_name    = "${aws_autoscaling_group.app.name}"
+  scaling_adjustment        = "${var.scale_out_adjustment}"
+  adjustment_type           = "ChangeInCapacity"
+  cooldown                  = "${var.autoscale_cooldown}"
+}
 
 resource "aws_cloudwatch_metric_alarm" "memory_reservation_high" {
   count               = "${ lookup(var.scale_out_thresholds, "memory_reservation", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryReservation-High"
-  alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by memory-reservation-high"
+  alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by memory-reservation"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "${var.scale_out_evaluation_periods}"
   metric_name         = "MemoryReservation"
@@ -172,16 +198,26 @@ resource "aws_cloudwatch_metric_alarm" "memory_reservation_high" {
 
   ok_actions          = ["${compact(var.scale_out_ok_actions)}"]
   alarm_actions       = [
-    "${aws_autoscaling_policy.scale_out.arn}",
+    "${aws_autoscaling_policy.memory_reservation_high.arn}",
     "${compact(var.scale_out_more_alarm_actions)}",
   ]
+}
+
+resource "aws_autoscaling_policy" "memory_reservation_low" {
+  count                  = "${ lookup(var.scale_in_thresholds, "memory_reservation", "") != "" ? 1 : 0 }"
+
+  name                   = "${aws_ecs_cluster.main.name}-scale_in-memory_reservation"
+  autoscaling_group_name = "${aws_autoscaling_group.app.name}"
+  scaling_adjustment     = "${var.scale_in_adjustment}"
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = "${var.autoscale_cooldown}"
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_reservation_low" {
   count               = "${ lookup(var.scale_in_thresholds, "memory_reservation", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryReservation-Low"
-  alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by memory-reservation-low"
+  alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by memory-reservation"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "${var.scale_in_evaluation_periods}"
   metric_name         = "MemoryReservation"
@@ -190,25 +226,34 @@ resource "aws_cloudwatch_metric_alarm" "memory_reservation_low" {
   statistic           = "Average"
   threshold           = "${var.scale_in_thresholds["memory_reservation"]}"
   treat_missing_data  = "notBreaching"
+  ok_actions          = ["${compact(var.scale_in_ok_actions)}"]
+  alarm_actions       = [
+    "${aws_autoscaling_policy.memory_reservation_low.arn}",
+    "${compact(var.scale_in_more_alarm_actions)}",
+  ]
 
   dimensions {
     ClusterName = "${aws_ecs_cluster.main.name}"
   }
-
-  ok_actions          = ["${compact(var.scale_in_ok_actions)}"]
-  alarm_actions       = [
-    "${aws_autoscaling_policy.scale_in.arn}",
-    "${compact(var.scale_in_more_alarm_actions)}",
-  ]
 }
 
 // CPU Reservation
+
+resource "aws_autoscaling_policy" "cpu_reservation_high" {
+  count                  = "${ lookup(var.scale_out_thresholds, "cpu_reservation", "") != "" ? 1 : 0 }"
+
+  name                   = "${aws_ecs_cluster.main.name}-scale_out-cpu_reservation"
+  autoscaling_group_name = "${aws_autoscaling_group.app.name}"
+  scaling_adjustment     = "${var.scale_out_adjustment}"
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = "${var.autoscale_cooldown}"
+}
 
 resource "aws_cloudwatch_metric_alarm" "cpu_reservation_high" {
   count               = "${ lookup(var.scale_out_thresholds, "cpu_reservation", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUReservation-High"
-  alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by cpu-reservation-high"
+  alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by cpu-reservation"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "${var.scale_out_evaluation_periods}"
   metric_name         = "CPUReservation"
@@ -217,23 +262,32 @@ resource "aws_cloudwatch_metric_alarm" "cpu_reservation_high" {
   statistic           = "Average"
   threshold           = "${var.scale_out_thresholds["cpu_reservation"]}"
   treat_missing_data  = "notBreaching"
+  ok_actions          = ["${compact(var.scale_out_ok_actions)}"]
+  alarm_actions       = [
+    "${aws_autoscaling_policy.cpu_reservation_high.arn}",
+    "${compact(var.scale_out_more_alarm_actions)}",
+  ]
 
   dimensions {
     ClusterName = "${aws_ecs_cluster.main.name}"
   }
+}
 
-  ok_actions          = ["${compact(var.scale_out_ok_actions)}"]
-  alarm_actions       = [
-    "${aws_autoscaling_policy.scale_out.arn}",
-    "${compact(var.scale_out_more_alarm_actions)}",
-  ]
+resource "aws_autoscaling_policy" "cpu_reservation_low" {
+  count                  = "${ lookup(var.scale_in_thresholds, "cpu_reservation", "") != "" ? 1 : 0 }"
+
+  name                   = "${aws_ecs_cluster.main.name}-scale_in-cpu_reservation"
+  autoscaling_group_name = "${aws_autoscaling_group.app.name}"
+  scaling_adjustment     = "${var.scale_in_adjustment}"
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = "${var.autoscale_cooldown}"
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_reservation_low" {
   count               = "${ lookup(var.scale_in_thresholds, "cpu_reservation", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUReservation-Low"
-  alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by cpu-reservation-low"
+  alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by cpu-reservation"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "${var.scale_in_evaluation_periods}"
   metric_name         = "CPUReservation"
@@ -242,14 +296,13 @@ resource "aws_cloudwatch_metric_alarm" "cpu_reservation_low" {
   statistic           = "Average"
   threshold           = "${var.scale_in_thresholds["cpu_reservation"]}"
   treat_missing_data  = "notBreaching"
+  ok_actions          = ["${compact(var.scale_in_ok_actions)}"]
+  alarm_actions       = [
+    "${aws_autoscaling_policy.cpu_reservation_low.arn}",
+    "${compact(var.scale_in_more_alarm_actions)}",
+  ]
 
   dimensions {
     ClusterName = "${aws_ecs_cluster.main.name}"
   }
-
-  ok_actions          = ["${compact(var.scale_in_ok_actions)}"]
-  alarm_actions       = [
-    "${aws_autoscaling_policy.scale_in.arn}",
-    "${compact(var.scale_in_more_alarm_actions)}",
-  ]
 }

--- a/service_load_balancing/autoscaling.tf
+++ b/service_load_balancing/autoscaling.tf
@@ -15,10 +15,12 @@ resource "aws_appautoscaling_target" "main" {
   service_namespace  = "ecs"
 }
 
-resource "aws_appautoscaling_policy" "scale_out" {
-  count              = "${ var.autoscale_iam_role_arn != "" ? 1 : 0 }"
+// Memory Utilization
 
-  name               = "${aws_ecs_service.main.name}-ecs-service-scale-out"
+resource "aws_appautoscaling_policy" "memory_high" {
+  count              = "${ lookup(var.scale_out_thresholds, "memory", "") != "" ? 1 : 0 }"
+
+  name               = "${aws_ecs_service.main.name}-ecs_service-scale_out-memory_utilization"
   resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
@@ -37,10 +39,36 @@ resource "aws_appautoscaling_policy" "scale_out" {
   depends_on         = ["aws_appautoscaling_target.main"]
 }
 
-resource "aws_appautoscaling_policy" "scale_in" {
-  count              = "${ var.autoscale_iam_role_arn != "" ? 1 : 0 }"
+resource "aws_cloudwatch_metric_alarm" "memory_high" {
+  count               = "${ lookup(var.scale_out_thresholds, "memory", "") != "" ? 1 : 0 }"
 
-  name               = "${aws_ecs_service.main.name}-ecs-service-scale-in"
+  alarm_name          = "${aws_ecs_service.main.name}-ECSService-MemoryUtilization-High"
+  alarm_description   = "${aws_ecs_service.main.name} scale-out pushed by memory-utilization"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "${var.scale_out_evaluation_periods}"
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = "${var.autoscale_cooldown}"
+  statistic           = "Average"
+  threshold           = "${var.scale_out_thresholds["memory"]}"
+  treat_missing_data  = "notBreaching"
+
+  dimensions {
+    ClusterName = "${var.cluster_name}"
+    ServiceName = "${aws_ecs_service.main.name}"
+  }
+
+  ok_actions          = ["${compact(var.scale_out_ok_actions)}"]
+  alarm_actions       = [
+    "${aws_appautoscaling_policy.memory_high.arn}",
+    "${compact(var.scale_out_more_alarm_actions)}",
+  ]
+}
+
+resource "aws_appautoscaling_policy" "memory_low" {
+  count              = "${ lookup(var.scale_in_thresholds, "memory", "") != "" ? 1 : 0 }"
+
+  name               = "${aws_ecs_service.main.name}-ecs_service-scale_in-memory_utilization"
   resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
@@ -59,39 +87,11 @@ resource "aws_appautoscaling_policy" "scale_in" {
   depends_on         = ["aws_appautoscaling_target.main"]
 }
 
-// Memory Utilization
-
-resource "aws_cloudwatch_metric_alarm" "memory_high" {
-  count               = "${ lookup(var.scale_out_thresholds, "memory", "") != "" ? 1 : 0 }"
-
-  alarm_name          = "${aws_ecs_service.main.name}-ECSService-MemoryUtilization-High"
-  alarm_description   = "${aws_ecs_service.main.name} scale-out pushed by memory-utilization-high"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "${var.scale_out_evaluation_periods}"
-  metric_name         = "MemoryUtilization"
-  namespace           = "AWS/ECS"
-  period              = "${var.autoscale_cooldown}"
-  statistic           = "Average"
-  threshold           = "${var.scale_out_thresholds["memory"]}"
-  treat_missing_data  = "notBreaching"
-
-  dimensions {
-    ClusterName = "${var.cluster_name}"
-    ServiceName = "${aws_ecs_service.main.name}"
-  }
-
-  ok_actions          = ["${compact(var.scale_out_ok_actions)}"]
-  alarm_actions       = [
-    "${aws_appautoscaling_policy.scale_out.arn}",
-    "${compact(var.scale_out_more_alarm_actions)}",
-  ]
-}
-
 resource "aws_cloudwatch_metric_alarm" "memory_low" {
   count               = "${ lookup(var.scale_in_thresholds, "memory", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_service.main.name}-ECSService-MemoryUtilization-Low"
-  alarm_description   = "scale-in pushed by memory-utilization-low"
+  alarm_description   = "${aws_ecs_service.main.name} scale-in pushed by memory-utilization"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "${var.scale_in_evaluation_periods}"
   metric_name         = "MemoryUtilization"
@@ -108,18 +108,40 @@ resource "aws_cloudwatch_metric_alarm" "memory_low" {
 
   ok_actions          = ["${compact(var.scale_in_ok_actions)}"]
   alarm_actions       = [
-    "${aws_appautoscaling_policy.scale_in.arn}",
+    "${aws_appautoscaling_policy.memory_low.arn}",
     "${compact(var.scale_in_more_alarm_actions)}",
   ]
 }
 
 // CPU Utilization
 
+resource "aws_appautoscaling_policy" "cpu_high" {
+  count              = "${ lookup(var.scale_out_thresholds, "cpu", "") != "" ? 1 : 0 }"
+
+  name               = "${aws_ecs_service.main.name}-ecs_service-scale_out-cpu_utilization"
+  resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = "${var.autoscale_cooldown}"
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = "${lookup(var.scale_out_step_adjustment, "metric_interval_lower_bound")}"
+      scaling_adjustment          = "${lookup(var.scale_out_step_adjustment, "scaling_adjustment")}"
+    }
+  }
+
+  depends_on         = ["aws_appautoscaling_target.main"]
+}
+
 resource "aws_cloudwatch_metric_alarm" "cpu_high" {
   count               = "${ lookup(var.scale_out_thresholds, "cpu", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_service.main.name}-ECSService-CPUUtilization-High"
-  alarm_description   = "${aws_ecs_service.main.name} scale-out pushed by cpu-utilization-high"
+  alarm_description   = "${aws_ecs_service.main.name} scale-out pushed by cpu-utilization"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "${var.scale_out_evaluation_periods}"
   metric_name         = "CPUUtilization"
@@ -136,16 +158,38 @@ resource "aws_cloudwatch_metric_alarm" "cpu_high" {
 
   ok_actions          = ["${compact(var.scale_out_ok_actions)}"]
   alarm_actions       = [
-    "${aws_appautoscaling_policy.scale_out.arn}",
+    "${aws_appautoscaling_policy.cpu_high.arn}",
     "${compact(var.scale_out_more_alarm_actions)}",
   ]
+}
+
+resource "aws_appautoscaling_policy" "cpu_low" {
+  count              = "${ lookup(var.scale_in_thresholds, "cpu", "") != "" ? 1 : 0 }"
+
+  name               = "${aws_ecs_service.main.name}-ecs_service-scale_in-cpu_utilization"
+  resource_id        = "service/${var.cluster_name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = "${var.autoscale_cooldown}"
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_upper_bound = "${lookup(var.scale_in_step_adjustment, "metric_interval_upper_bound")}"
+      scaling_adjustment          = "${lookup(var.scale_in_step_adjustment, "scaling_adjustment")}"
+    }
+  }
+
+  depends_on         = ["aws_appautoscaling_target.main"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_low" {
   count               = "${ lookup(var.scale_in_thresholds, "cpu", "") != "" ? 1 : 0 }"
 
   alarm_name          = "${aws_ecs_service.main.name}-ECSService-CPUUtilization-Low"
-  alarm_description   = "${aws_ecs_service.main.name} scale-in pushed by cpu-utilization-low"
+  alarm_description   = "${aws_ecs_service.main.name} scale-in pushed by cpu-utilization"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "${var.scale_in_evaluation_periods}"
   metric_name         = "CPUUtilization"
@@ -162,7 +206,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_low" {
 
   ok_actions          = ["${compact(var.scale_in_ok_actions)}"]
   alarm_actions       = [
-    "${aws_appautoscaling_policy.scale_in.arn}",
+    "${aws_appautoscaling_policy.cpu_low.arn}",
     "${compact(var.scale_in_more_alarm_actions)}",
   ]
 }


### PR DESCRIPTION
Scope of modules: `service_load_balnacing` `cluster`

When set multiple values of `scale_out_thresholds` `scale_in_thresholds`, created only one auto-scaling source...

cause autoscaling policy is duplicated on there terraform module,
and hope to fix it that sets multiple & unique policy of autoscaling / appautoscaling. 🙏 