### PR TITLE
Deprecated, use ordered_placement_strategy instead

### DIFF
--- a/service_load_balancing/launch_type_ec2.tf
+++ b/service_load_balancing/launch_type_ec2.tf
@@ -18,7 +18,7 @@ resource "aws_ecs_service" "main" {
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
 
-  placement_strategy {
+  ordered_placement_strategy {
     type  = "${var.placement_strategy_type}"
     field = "${var.placement_strategy_field}"
   }


### PR DESCRIPTION
`placement_strategy` block is already deprecated, and use `ordered_placement_strategy` block.

[nits] that block can be declared multiple.
For now, this proposal is supporting single block cause variable args is so difficult ...

https://www.terraform.io/docs/providers/aws/r/ecs_service.html#placement_strategy

## BC-BREAKS

If apply to existing resource that mean as updating, 
resource `aws_ecs_service` is force renew... like this

```
      ordered_placement_strategy.#:              "" => "1" (forces new resource)
      ordered_placement_strategy.0.field:        "" => "instanceId" (forces new resource)
      ordered_placement_strategy.0.type:         "" => "spread" (forces new resource)
      placement_strategy.#:                      "1" => "0" (forces new resource)
      placement_strategy.2750134989.field:       "instanceId" => "" (forces new resource)
      placement_strategy.2750134989.type:        "spread" => "" (forces new resource)
```

Related: https://github.com/terraform-providers/terraform-provider-aws/issues/4557

If you want update without destroy, need edit .tfstate file