### PR TITLE
Parameterize to the root volume_size

### DIFF
--- a/cluster/README.rst
+++ b/cluster/README.rst
@@ -137,3 +137,22 @@ Adding sns-notification for autoscaling-group scales
 See more details about `Getting SNS Notifications When Your Auto Scaling Group Scales`_ in the official AWS docs.
 
 .. _Getting SNS Notifications When Your Auto Scaling Group Scales: http://docs.aws.amazon.com/autoscaling/latest/userguide/ASGettingNotifications.html
+
+
+Guard CannotInspectContainerError attributables to EBS I/O
+----------------------------------------------------------
+
+Specify volume_size of root_block_device if U want perform to size, and iops
+
+.. code:: hcl
+
+   module "ecs_cluster" {
+      # ...
+
+      root_volume_size = 100
+   }
+
+See more details about `Storage Configuration`_ `General Purpose SSD (gp2) Volumes`_ in the official AWS docs.
+
+.. _Storage Configuration: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-ami-storage-config.html
+.. _General Purpose SSD (gp2) Volumes: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html#EBSVolumeTypes_gp2

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -44,10 +44,17 @@ resource "aws_launch_configuration" "app" {
   associate_public_ip_address = "${var.associate_public_ip_address}"
   enable_monitoring           = true
 
+  root_block_device {
+    volume_type           = "gp2"
+    volume_size           = "${var.root_volume_size}"
+    delete_on_termination = true
+  }
+
   # NOTE: Currently no-support to customizing block device(s)
-  #       - OS specified image_id is not always using /dev/xvdcz as docker storage
-  #       - As a workaround, creates the ami that it is customizing to the block device mappings
-  #root_block_device {}
+  #   - OS specified image_id is not always using /dev/xvdcz as docker storage
+  #   - As a workaround, creates the ami that it is customizing to the block device mappings
+  #
+  # DOCS: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-ami-storage-config.html
   #ebs_block_device  { device_name = "/dev/xvdcz" }
 
   lifecycle {

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -112,6 +112,11 @@ variable "asg_extra_tags" {
   */]
 }
 
+variable "root_volume_size" {
+  description = "The size of the root volume in gigabytes"
+  default     = 8
+}
+
 # AutoScaling
 
 variable "autoscale_notification_ok_topic_arn" {


### PR DESCRIPTION
Occurred error like as https://github.com/aws/amazon-ecs-agent/issues/336

Hope to supporting changes volume_size on `./cluster` (ec2) module

[nits] 8 (GB) is default by amzn-linux ecs optimized ami