### PR TITLE
Fix output error when var.log_groups is empty list

### DIFF
--- a/service_load_balancing/outputs.tf
+++ b/service_load_balancing/outputs.tf
@@ -3,9 +3,9 @@ output "service_name" {
 }
 
 output "log_group_name" {
-  value = aws_cloudwatch_log_group.app[0].name
+  value = length(var.log_groups) > 0 ? aws_cloudwatch_log_group.app[0].name : ""
 }
 
 output "log_group_arn" {
-  value = aws_cloudwatch_log_group.app[0].arn
+  value = length(var.log_groups) > 0 ? aws_cloudwatch_log_group.app[0].arn : ""
 }


### PR DESCRIPTION
Fix error following when var.log_group by the default (empty list)

```
Error: Invalid index

  on .terraform/modules/{example}/service_load_balancing/outputs.tf line 6, in output "log_group_name":
   6:   value = aws_cloudwatch_log_group.app[0].name
    |----------------
    | aws_cloudwatch_log_group.app is empty tuple
```