### PR TITLE
support terraform versions >= 13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ OS_TYPE  = $(shell echo $(shell uname) | tr A-Z a-z)
 OS_ARCH := amd64
 
 TERRAFORM         := ./terraform
-TERRAFORM_VERSION := 0.12.9
+TERRAFORM_VERSION := 0.13.5
 TERRAFORM_URL      = https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_$(OS_TYPE)_$(OS_ARCH).zip
 
 EXCLUDES_DIRS := _test _example .terraform

--- a/_test/tf_fixtures/fixture_providers.tf
+++ b/_test/tf_fixtures/fixture_providers.tf
@@ -1,10 +1,5 @@
 provider "aws" {
   # https://github.com/terraform-providers/terraform-provider-aws/releases
-  version = "~> 2.28"
+  version = "~> 3.20"
   region  = "ap-northeast-1"
-}
-
-provider "template" {
-  # https://github.com/terraform-providers/terraform-provider-template/releases
-  version = "~> 2.1"
 }

--- a/cluster/versions.tf
+++ b/cluster/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/service_load_balancing/versions.tf
+++ b/service_load_balancing/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }


### PR DESCRIPTION
We want to support up to one previous terraform version than the latest
(currently latest as 14)