### PR TITLE
add managed_termination_protection & managed_draining

### DIFF
--- a/cluster/autoscaling.tf
+++ b/cluster/autoscaling.tf
@@ -29,7 +29,7 @@ resource "aws_autoscaling_notification" "ng" {
 // Memory Utilization
 
 resource "aws_autoscaling_policy" "memory_util_high" {
-  count = lookup(var.scale_out_thresholds, "memory_util", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_out_thresholds, "memory_util", "") != "" ? 1 : 0
 
   name                   = "${aws_ecs_cluster.main.name}-scale_out-memory_util"
   autoscaling_group_name = aws_autoscaling_group.app.name
@@ -39,7 +39,7 @@ resource "aws_autoscaling_policy" "memory_util_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_util_high" {
-  count = lookup(var.scale_out_thresholds, "memory_util", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_out_thresholds, "memory_util", "") != "" ? 1 : 0
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryUtilization-High"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by memory-util"
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_util_high" {
 }
 
 resource "aws_autoscaling_policy" "memory_util_low" {
-  count = lookup(var.scale_in_thresholds, "memory_util", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_in_thresholds, "memory_util", "") != "" ? 1 : 0
 
   name                   = "${aws_ecs_cluster.main.name}-scale_in-memory_util"
   autoscaling_group_name = aws_autoscaling_group.app.name
@@ -75,7 +75,7 @@ resource "aws_autoscaling_policy" "memory_util_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_util_low" {
-  count = lookup(var.scale_in_thresholds, "memory_util", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider  && lookup(var.scale_in_thresholds, "memory_util", "") != "" ? 1 : 0
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryUtilization-Low"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by memory-util"
@@ -103,7 +103,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_util_low" {
 // CPU Utilization
 
 resource "aws_autoscaling_policy" "cpu_util_high" {
-  count = lookup(var.scale_out_thresholds, "cpu_util", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_out_thresholds, "cpu_util", "") != "" ? 1 : 0
 
   name                   = "${aws_ecs_cluster.main.name}-scale_out-cpu_util"
   autoscaling_group_name = aws_autoscaling_group.app.name
@@ -113,7 +113,7 @@ resource "aws_autoscaling_policy" "cpu_util_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_util_high" {
-  count = lookup(var.scale_out_thresholds, "cpu_util", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_out_thresholds, "cpu_util", "") != "" ? 1 : 0
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUUtilization-High"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by cpu-util"
@@ -139,7 +139,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_util_high" {
 }
 
 resource "aws_autoscaling_policy" "cpu_util_low" {
-  count = lookup(var.scale_in_thresholds, "cpu_util", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_in_thresholds, "cpu_util", "") != "" ? 1 : 0
 
   name                   = "${aws_ecs_cluster.main.name}-scale_in-cpu_util"
   autoscaling_group_name = aws_autoscaling_group.app.name
@@ -149,7 +149,7 @@ resource "aws_autoscaling_policy" "cpu_util_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_util_low" {
-  count = lookup(var.scale_in_thresholds, "cpu_util", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_in_thresholds, "cpu_util", "") != "" ? 1 : 0
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUUtilization-Low"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by cpu-util"
@@ -177,7 +177,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_util_low" {
 // Memory Reservation
 
 resource "aws_autoscaling_policy" "memory_reservation_high" {
-  count = lookup(var.scale_out_thresholds, "memory_reservation", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_out_thresholds, "memory_reservation", "") != "" ? 1 : 0
 
   name                   = "${aws_ecs_cluster.main.name}-scale_out-memory_reservation"
   autoscaling_group_name = aws_autoscaling_group.app.name
@@ -187,7 +187,7 @@ resource "aws_autoscaling_policy" "memory_reservation_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_reservation_high" {
-  count = lookup(var.scale_out_thresholds, "memory_reservation", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_out_thresholds, "memory_reservation", "") != "" ? 1 : 0
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryReservation-High"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by memory-reservation"
@@ -214,7 +214,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_reservation_high" {
 }
 
 resource "aws_autoscaling_policy" "memory_reservation_low" {
-  count = lookup(var.scale_in_thresholds, "memory_reservation", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_in_thresholds, "memory_reservation", "") != "" ? 1 : 0
 
   name                   = "${aws_ecs_cluster.main.name}-scale_in-memory_reservation"
   autoscaling_group_name = aws_autoscaling_group.app.name
@@ -224,7 +224,7 @@ resource "aws_autoscaling_policy" "memory_reservation_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_reservation_low" {
-  count = lookup(var.scale_in_thresholds, "memory_reservation", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_in_thresholds, "memory_reservation", "") != "" ? 1 : 0
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-MemoryReservation-Low"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by memory-reservation"
@@ -252,7 +252,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_reservation_low" {
 // CPU Reservation
 
 resource "aws_autoscaling_policy" "cpu_reservation_high" {
-  count = lookup(var.scale_out_thresholds, "cpu_reservation", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_out_thresholds, "cpu_reservation", "") != "" ? 1 : 0
 
   name                   = "${aws_ecs_cluster.main.name}-scale_out-cpu_reservation"
   autoscaling_group_name = aws_autoscaling_group.app.name
@@ -262,7 +262,7 @@ resource "aws_autoscaling_policy" "cpu_reservation_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_reservation_high" {
-  count = lookup(var.scale_out_thresholds, "cpu_reservation", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_out_thresholds, "cpu_reservation", "") != "" ? 1 : 0
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUReservation-High"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-out pushed by cpu-reservation"
@@ -288,7 +288,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_reservation_high" {
 }
 
 resource "aws_autoscaling_policy" "cpu_reservation_low" {
-  count = lookup(var.scale_in_thresholds, "cpu_reservation", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_in_thresholds, "cpu_reservation", "") != "" ? 1 : 0
 
   name                   = "${aws_ecs_cluster.main.name}-scale_in-cpu_reservation"
   autoscaling_group_name = aws_autoscaling_group.app.name
@@ -298,7 +298,7 @@ resource "aws_autoscaling_policy" "cpu_reservation_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_reservation_low" {
-  count = lookup(var.scale_in_thresholds, "cpu_reservation", "") != "" ? 1 : 0
+  count = !var.use_ecs_capacity_provider && lookup(var.scale_in_thresholds, "cpu_reservation", "") != "" ? 1 : 0
 
   alarm_name          = "${aws_ecs_cluster.main.name}-ECSCluster-CPUReservation-Low"
   alarm_description   = "${aws_ecs_cluster.main.name} scale-in pushed by cpu-reservation"

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -12,7 +12,7 @@ variable "iam_path" {
 variable "iam_policy_arns" {
   description = "IAM policy arns for container instance"
   type        = list(string)
-  default = [
+  default     = [
     "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
   ]
 }
@@ -75,7 +75,7 @@ variable "asg_default_cooldown" {
 variable "asg_enabled_metrics" {
   description = "A list of metrics to collect in AutoScaling Group"
   type        = list(string)
-  default = [
+  default     = [
   ]
   # http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-monitoring.html#as-enable-group-metrics
   # Candidates is bellow as:
@@ -100,7 +100,7 @@ variable "asg_termination_policies" {
 variable "asg_extra_tags" {
   description = "AWS EC2 Tag for AutoScaling Group (and attached instances)"
   type        = list
-  default = [
+  default     = [
   ]
   /*
     # like: https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#interpolated-tags
@@ -208,6 +208,50 @@ variable "scale_in_more_alarm_actions" {
   description = "For scale-in as same as alarm actions for cloudwatch alarms"
   type        = list(string)
   default     = []
+}
+
+# ECS capacity provider
+
+variable "use_ecs_capacity_provider" {
+  description = "Use ECS capacity provider"
+  type        = bool
+  default     = false
+}
+
+variable "managed_draining" {
+  description = "Enable managed draining"
+  type        = string
+  default     = "ENABLED"
+}
+
+variable "managed_termination_protection" {
+    description = "Enable managed termination protection"
+    type        = string
+    default     = "ENABLED"
+}
+
+variable "managed_scaling_status" {
+  description = "The managed scaling status of the ECS capacity provider"
+  type        = string
+  default     = "ENABLED"
+}
+
+variable "maximum_scaling_step_size" {
+  description = "The maximum number of instances that can be added or removed from the Auto Scaling group in a single scaling action"
+  type        = number
+  default     = 1
+}
+
+variable "minimum_scaling_step_size" {
+  description = "The minimum number of instances that can be added or removed from the Auto Scaling group in a single scaling action"
+  type        = number
+  default     = 1
+}
+
+variable "target_capacity" {
+  description = "The target capacity of the ECS capacity provider"
+  type        = number
+  default     = 1
 }
 
 # Cloudwatch Log Group


### PR DESCRIPTION
Support `managed_termination_protection` and `managed_draining` in ecs capacity provider.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_capacity_provider

NOTE: ecs managed scaling is disabled, because scaling are managed by autoscaling policy + cloudwatch alarm.