### PR TITLE
add asg protect_from_scale_in

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -12,8 +12,9 @@ resource "aws_autoscaling_group" "app" {
   name            = aws_ecs_cluster.main.name
   enabled_metrics = var.asg_enabled_metrics
 
-  launch_configuration = aws_launch_configuration.app.name
-  termination_policies = var.asg_termination_policies
+  launch_configuration  = aws_launch_configuration.app.name
+  protect_from_scale_in = var.asg_protect_from_scale_in
+  termination_policies  = var.asg_termination_policies
 
   # NOTE: this module no handled desired capacity
   #desired_capacity     = "${var.asg_desired}"

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -91,6 +91,12 @@ variable "asg_enabled_metrics" {
     */
 }
 
+variable "asg_protect_from_scale_in" {
+  description = "AutoScaling Group protect_from_scale_in"
+  type        = bool
+  default     = false
+}
+
 variable "asg_termination_policies" {
   description = "AutoScaling Group termination_policies"
   type        = list(string)


### PR DESCRIPTION
When using managed termination protection in ecs capacity provider, instance scale-in protection is required

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html
https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-instance-protection.html