### PR TITLE
launch_configuration is deprecated & use launch templates instead

### DIFF
--- a/cluster/autoscaling.tf
+++ b/cluster/autoscaling.tf
@@ -7,23 +7,23 @@
 resource "aws_autoscaling_notification" "ok" {
   count = var.autoscale_notification_ok_topic_arn != "" ? 1 : 0
 
-  group_names   = [aws_autoscaling_group.app.name]
+  group_names = [aws_autoscaling_group.app.name]
   notifications = [
     "autoscaling:EC2_INSTANCE_LAUNCH",
     "autoscaling:EC2_INSTANCE_TERMINATE",
   ]
-  topic_arn     = var.autoscale_notification_ok_topic_arn
+  topic_arn = var.autoscale_notification_ok_topic_arn
 }
 
 resource "aws_autoscaling_notification" "ng" {
   count = var.autoscale_notification_ng_topic_arn != "" ? 1 : 0
 
-  group_names   = [aws_autoscaling_group.app.name]
+  group_names = [aws_autoscaling_group.app.name]
   notifications = [
     "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
     "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
   ]
-  topic_arn     = var.autoscale_notification_ng_topic_arn
+  topic_arn = var.autoscale_notification_ng_topic_arn
 }
 
 // Memory Utilization
@@ -52,7 +52,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_util_high" {
   threshold           = var.scale_out_thresholds["memory_util"]
   treat_missing_data  = "notBreaching"
   ok_actions          = compact(var.scale_out_ok_actions)
-  alarm_actions       = compact(
+  alarm_actions = compact(
     concat(
       [aws_autoscaling_policy.memory_util_high[0].arn],
       var.scale_out_more_alarm_actions,
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_util_low" {
   threshold           = var.scale_in_thresholds["memory_util"]
   treat_missing_data  = "notBreaching"
   ok_actions          = compact(var.scale_in_ok_actions)
-  alarm_actions       = compact(
+  alarm_actions = compact(
     concat(
       [aws_autoscaling_policy.memory_util_low[0].arn],
       var.scale_in_more_alarm_actions,
@@ -126,11 +126,11 @@ resource "aws_cloudwatch_metric_alarm" "cpu_util_high" {
   threshold           = var.scale_out_thresholds["cpu_util"]
   treat_missing_data  = "notBreaching"
   ok_actions          = compact(var.scale_out_ok_actions)
-  alarm_actions       = compact(
-  concat(
-  [aws_autoscaling_policy.cpu_util_high[0].arn],
-  var.scale_out_more_alarm_actions,
-  ),
+  alarm_actions = compact(
+    concat(
+      [aws_autoscaling_policy.cpu_util_high[0].arn],
+      var.scale_out_more_alarm_actions,
+    ),
   )
 
   dimensions = {
@@ -162,7 +162,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_util_low" {
   threshold           = var.scale_in_thresholds["cpu_util"]
   treat_missing_data  = "notBreaching"
   ok_actions          = compact(var.scale_in_ok_actions)
-  alarm_actions       = compact(
+  alarm_actions = compact(
     concat(
       [aws_autoscaling_policy.cpu_util_low[0].arn],
       var.scale_in_more_alarm_actions,
@@ -204,7 +204,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_reservation_high" {
     ClusterName = aws_ecs_cluster.main.name
   }
 
-  ok_actions    = compact(var.scale_out_ok_actions)
+  ok_actions = compact(var.scale_out_ok_actions)
   alarm_actions = compact(
     concat(
       [aws_autoscaling_policy.memory_reservation_high[0].arn],
@@ -237,7 +237,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_reservation_low" {
   threshold           = var.scale_in_thresholds["memory_reservation"]
   treat_missing_data  = "notBreaching"
   ok_actions          = compact(var.scale_in_ok_actions)
-  alarm_actions       = compact(
+  alarm_actions = compact(
     concat(
       [aws_autoscaling_policy.memory_reservation_low[0].arn],
       var.scale_in_more_alarm_actions,
@@ -275,7 +275,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_reservation_high" {
   threshold           = var.scale_out_thresholds["cpu_reservation"]
   treat_missing_data  = "notBreaching"
   ok_actions          = compact(var.scale_out_ok_actions)
-  alarm_actions       = compact(
+  alarm_actions = compact(
     concat(
       [aws_autoscaling_policy.cpu_reservation_high[0].arn],
       var.scale_out_more_alarm_actions,
@@ -311,7 +311,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_reservation_low" {
   threshold           = var.scale_in_thresholds["cpu_reservation"]
   treat_missing_data  = "notBreaching"
   ok_actions          = compact(var.scale_in_ok_actions)
-  alarm_actions       = compact(
+  alarm_actions = compact(
     concat(
       [aws_autoscaling_policy.cpu_reservation_low[0].arn],
       var.scale_in_more_alarm_actions,

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -14,7 +14,8 @@ resource "aws_autoscaling_group" "app" {
 
   launch_configuration = var.use_launch_template ? null : aws_launch_configuration.app.name
   launch_template {
-    id = var.use_launch_template ? aws_launch_template.app.id : null
+    id      = var.use_launch_template ? aws_launch_template.app.id : null
+    version = var.use_launch_template ? aws_launch_template.app.latest_version : null
   }
 
   protect_from_scale_in = var.asg_protect_from_scale_in

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -85,7 +85,7 @@ resource "aws_launch_template" "app" {
   user_data     = var.user_data
 
   block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = var.root_device_name
     ebs {
       volume_type           = "gp3"
       volume_size           = var.root_volume_size

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -36,7 +36,7 @@ resource "aws_autoscaling_group" "app" {
   lifecycle {
     create_before_destroy = true
     # NOTE: changed automacally by autoscale policy
-    ignore_changes        = [desired_capacity]
+    ignore_changes = [desired_capacity]
   }
 }
 
@@ -67,5 +67,35 @@ resource "aws_launch_configuration" "app" {
 
   lifecycle {
     create_before_destroy = true
+  }
+}
+
+resource "aws_launch_template" "app" {
+  name_prefix          = "${aws_ecs_cluster.main.name}-"
+  security_group_names = var.security_groups
+  key_name             = var.key_name
+  image_id             = var.ami_id
+  instance_type        = var.instance_type
+  ebs_optimized        = var.ebs_optimized
+  user_data            = var.user_data
+
+  block_device_mappings {
+    ebs {
+      volume_type           = "gp3"
+      volume_size           = var.root_volume_size
+      delete_on_termination = true
+    }
+  }
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ecs_instance.name
+  }
+
+  network_interfaces {
+    associate_public_ip_address = var.associate_public_ip_address
+  }
+
+  monitoring {
+    enabled = true
   }
 }

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -77,13 +77,12 @@ resource "aws_launch_configuration" "app" {
 }
 
 resource "aws_launch_template" "app" {
-  name_prefix          = "${aws_ecs_cluster.main.name}-"
-  security_group_names = var.security_groups
-  key_name             = var.key_name
-  image_id             = var.ami_id
-  instance_type        = var.instance_type
-  ebs_optimized        = var.ebs_optimized
-  user_data            = var.user_data
+  name_prefix   = "${aws_ecs_cluster.main.name}-"
+  key_name      = var.key_name
+  image_id      = var.ami_id
+  instance_type = var.instance_type
+  ebs_optimized = var.ebs_optimized
+  user_data     = var.user_data
 
   block_device_mappings {
     ebs {
@@ -98,6 +97,7 @@ resource "aws_launch_template" "app" {
   }
 
   network_interfaces {
+    security_groups             = var.security_groups
     associate_public_ip_address = var.associate_public_ip_address
   }
 

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -12,7 +12,12 @@ resource "aws_autoscaling_group" "app" {
   name            = aws_ecs_cluster.main.name
   enabled_metrics = var.asg_enabled_metrics
 
-  launch_configuration  = aws_launch_configuration.app.name
+  # NOTE: launch_configuration is deprecated
+  launch_configuration = var.use_launch_template ? null : aws_launch_configuration.app[0].name
+  launch_template {
+    id = var.use_launch_template ? aws_launch_template.app[0].id : null
+  }
+
   protect_from_scale_in = var.asg_protect_from_scale_in
   termination_policies  = var.asg_termination_policies
 
@@ -41,6 +46,7 @@ resource "aws_autoscaling_group" "app" {
 }
 
 resource "aws_launch_configuration" "app" {
+  count                       = var.use_launch_template ? 0 : 1
   name_prefix                 = "${aws_ecs_cluster.main.name}-"
   security_groups             = var.security_groups
   key_name                    = var.key_name
@@ -71,6 +77,7 @@ resource "aws_launch_configuration" "app" {
 }
 
 resource "aws_launch_template" "app" {
+  count                = var.use_launch_template ? 1 : 0
   name_prefix          = "${aws_ecs_cluster.main.name}-"
   security_group_names = var.security_groups
   key_name             = var.key_name

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -85,6 +85,7 @@ resource "aws_launch_template" "app" {
   user_data     = var.user_data
 
   block_device_mappings {
+    device_name = "/dev/xvda"
     ebs {
       volume_type           = "gp3"
       volume_size           = var.root_volume_size

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -12,10 +12,9 @@ resource "aws_autoscaling_group" "app" {
   name            = aws_ecs_cluster.main.name
   enabled_metrics = var.asg_enabled_metrics
 
-  # NOTE: launch_configuration is deprecated
-  launch_configuration = var.use_launch_template ? null : aws_launch_configuration.app[0].name
+  launch_configuration = var.use_launch_template ? null : aws_launch_configuration.app.name
   launch_template {
-    id = var.use_launch_template ? aws_launch_template.app[0].id : null
+    id = var.use_launch_template ? aws_launch_template.app.id : null
   }
 
   protect_from_scale_in = var.asg_protect_from_scale_in
@@ -45,8 +44,8 @@ resource "aws_autoscaling_group" "app" {
   }
 }
 
+# NOTE: launch_configuration is deprecated
 resource "aws_launch_configuration" "app" {
-  count                       = var.use_launch_template ? 0 : 1
   name_prefix                 = "${aws_ecs_cluster.main.name}-"
   security_groups             = var.security_groups
   key_name                    = var.key_name
@@ -77,7 +76,6 @@ resource "aws_launch_configuration" "app" {
 }
 
 resource "aws_launch_template" "app" {
-  count                = var.use_launch_template ? 1 : 0
   name_prefix          = "${aws_ecs_cluster.main.name}-"
   security_group_names = var.security_groups
   key_name             = var.key_name

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -127,7 +127,7 @@ variable "root_volume_size" {
 variable "use_launch_template" {
   description = "Use launch template instead of launch configuration"
   type        = bool
-  default     = false
+  default     = true
 }
 
 # AutoScaling

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -124,6 +124,12 @@ variable "root_volume_size" {
   default     = 8
 }
 
+variable "use_launch_template" {
+  description = "Use launch template instead of launch configuration"
+  type        = bool
+  default     = false
+}
+
 # AutoScaling
 
 variable "autoscale_notification_ok_topic_arn" {

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -32,6 +32,11 @@ variable "ami_id" {
   type        = string
 }
 
+variable "root_device_name" {
+  description = "using the aws_ami data source root_device_name attribute"
+  type        = string
+}
+
 variable "vpc_zone_identifier" {
   description = "AWS vpc zone identifier(s)"
   type        = list(string)

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -35,6 +35,7 @@ variable "ami_id" {
 variable "root_device_name" {
   description = "using the aws_ami data source root_device_name attribute"
   type        = string
+  default     = ""
 }
 
 variable "vpc_zone_identifier" {

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -105,7 +105,7 @@ variable "asg_termination_policies" {
 
 variable "asg_extra_tags" {
   description = "AWS EC2 Tag for AutoScaling Group (and attached instances)"
-  type        = list
+  type        = list(any)
   default = [
   ]
   /*


### PR DESCRIPTION
The use of launch configurations is discouraged in favor of launch templates. 
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration

Two variables are added
``` variable "use_launch_template"  ```  default value is true.
``` variable "root_device_name" ``` default value is empty. Used only in launch_template.
It is recommended to use the root_device_name attribute of the aws_ami data source.



