### PR TITLE
support medatada options

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -71,6 +71,15 @@ resource "aws_launch_configuration" "app" {
   # DOCS: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-ami-storage-config.html
   #ebs_block_device  { device_name = "/dev/xvdcz" }
 
+  dynamic "metadata_options" {
+    for_each = length(var.metadata_options) > 0 ? [var.metadata_options] : []
+    content {
+      http_endpoint               = try(metadata_options.value.http_endpoint, null)
+      http_tokens                 = try(metadata_options.value.http_tokens, null)
+      http_put_response_hop_limit = try(metadata_options.value.http_put_response_hop_limit, null)
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
   }
@@ -100,6 +109,17 @@ resource "aws_launch_template" "app" {
   network_interfaces {
     security_groups             = var.security_groups
     associate_public_ip_address = var.associate_public_ip_address
+  }
+
+  dynamic "metadata_options" {
+    for_each = length(var.metadata_options) > 0 ? [var.metadata_options] : []
+    content {
+      http_endpoint               = try(metadata_options.value.http_endpoint, null)
+      http_tokens                 = try(metadata_options.value.http_tokens, null)
+      http_put_response_hop_limit = try(metadata_options.value.http_put_response_hop_limit, null)
+      http_protocol_ipv6          = try(metadata_options.value.http_protocol_ipv6, null)
+      instance_metadata_tags      = try(metadata_options.value.instance_metadata_tags, null)
+    }
   }
 
   monitoring {

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -125,6 +125,12 @@ variable "asg_extra_tags" {
   */
 }
 
+variable "metadata_options" {
+  description = "Customize the metadata options for the instance"
+  type        = map(string)
+  default     = {}
+}
+
 variable "root_volume_size" {
   description = "The size of the root volume in gigabytes"
   default     = 8
@@ -199,7 +205,7 @@ variable "scale_in_thresholds" {
   description = "The values against which the specified statistic is compared for scale_in"
   type        = map(string)
   default     = {}
-  # Supporting thresholds as berow
+  # Supporting thresholds as bellow
   #cpu_util           = // e.g.  5
   #cpu_reservation    = // e.g.  5
   #memory_util        = // e.g. 40


### PR DESCRIPTION
support medatada_options for launch_template/launch_configuration

- lauch_configuration: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration#metadata_options
- laucnh_template: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template#metadata-options